### PR TITLE
Variadic Typing

### DIFF
--- a/src/js/trove/global.js
+++ b/src/js/trove/global.js
@@ -524,7 +524,9 @@
         "_greaterequal": ["arrow", ["String"], "Boolean"]
       }],
       "Table": ["data", "Table", [], [], {
-        "length": ["arrow", [], "Number"]
+        "length": ["arrow", [], "Number"],
+        // TODO: defined correctly using variadic types
+        "row": ["arrow", ["tany"], "tany"],
       }],
       "Row": ["data", "Row", [], [], { }],
       "Function": ["data", "Function", [], [], {}],

--- a/tests/type-check/good/table.arr
+++ b/tests/type-check/good/table.arr
@@ -11,3 +11,13 @@ tbl = table: name, age
   row: "Alice", 15
   row: "Eve", 13
 end
+
+wider-tbl = table: name, age, gender
+end
+
+even-wider-tbl = table: name, age, gender, address
+end
+
+tbl.row("Foo", 11)
+wider-tbl.row("Foo", 11, "male")
+even-wider-tbl.row("Foo", 11, "male", "123 Main St.")


### PR DESCRIPTION
# Variadic Typing

Table's `.row` is only (afaik) variadic method in Pyret today. Thus, typing this is a novel challenge.

***

## table.row()

Given a table:

```
tbl = table: name, age
  row: "Bob", 12
  row: "Alice", 15
  row: "Eve", 13
end
```

`.row` will return a row based on the given table's schema and an collection of corresponding row values:

```
> tbl.row("Rob", 10)

Row < { "name": "Rob", "age": 10 } >
```

### Current Status

Input values possess the following properties:
* *order dependent:* matches columns implicitly (i.e. in the above, input 1 is `name` and input 2 is `age`)
* *variable arity:* must match # of columns in table's schema, but tables can be of indefinite column length
* *no type checking:* while not ideal, at the moment the value is not type checked against the column's sort, thus for the above, `tbl.row(100, True)` will not fail at runtime (or compile time).

### An Initial Typing

```
row :: (*Any) -> Row
```

Pros:
* allows for indefinite arity which will be checked at compile time

Cons:
* no type checking on type of inputs, thus might not match expected column sorts

### An Ideal Typing

```
row :: ([T1, T2, ... Tn)*) -> Row
```

Pros:
* allows for indefinite arity which will be checked at compile time
* type checking on type of inputs

Cons:
* no clue how to do this... is this even possible in today's state of affairs at compile time?

***

## Variadic Typing in General

***

## References

* [PEP 646 - Variadic Generics](https://peps.python.org/pep-0646/#specification)